### PR TITLE
Ticket 75 review test requirement for statistics on departure

### DIFF
--- a/tests/test_statistics.c
+++ b/tests/test_statistics.c
@@ -157,6 +157,25 @@ void test_statistics_on_departure_adds_park_duration() {
 	assert(stats.currently_parked == 3);
 }
 
+/*
+Test 2:
+Negative Parkdauer wird als 0 behandelt.
+Die Parkdauer-Summe bleibt gleich, der Abfahrtszaehler steigt trotzdem um 1.
+*/
+void test_statistics_on_departure_normalizes_negative_duration() {
+	Statistics stats = {0};
+
+	stats.total_park_duration = 20;
+	stats.departed_vehicle_count = 4;
+	stats.currently_queued = 2;
+
+	statistics_on_departure(&stats, -7);
+
+	assert(stats.total_park_duration == 20);
+	assert(stats.departed_vehicle_count == 5);
+	assert(stats.currently_queued == 2);
+}
+
 
 
 


### PR DESCRIPTION
Habe nun nochmal zwei Tests geschrieben. 
Test 1:
Bei positiver Parkdauer soll die Parkdauer aufsummiert
und der Zaehler ausgefahrener Fahrzeuge um 1 erhoeht werden.

Test 2:
Negative Parkdauer wird als 0 behandelt.
Die Parkdauer-Summe bleibt gleich, der Abfahrtszaehler steigt trotzdem um 1.